### PR TITLE
Fix invalid escaping

### DIFF
--- a/behavex/outputs/jinja/main.jinja2
+++ b/behavex/outputs/jinja/main.jinja2
@@ -882,7 +882,7 @@
                     labels: [
                         {%- for step_name, step_dict in steps.items() -%}
                             {%- if step_dict["overall_status"] == "passed" -%}
-                                '{{step_name|safe|replace("'", "&#39;")}}',
+                                '{{step_name}}',
                             {%- endif -%}
                         {%- endfor -%}
                         ],
@@ -899,7 +899,7 @@
                     labels: [
                         {%- for step_name, step_dict in steps.items() -%}
                             {%- if step_dict["overall_status"] == "failed" -%}
-                                '{{step_name|safe|replace("'", "&#39;")}}',
+                                '{{step_name}}',
                             {%- endif -%}
                         {%- endfor -%}
                         ],


### PR DESCRIPTION
Fixes #17 
The filters are note being applied correctly, the single quote is only escaped either if safe and replace("'", "&#39;") are removed or if it's used {{step_name|replace("'", "&#39;")|safe}} instead of {{step_name|safe|replace("'", "&#39;")}}

Possible cause it that the use of replace as the last filter is messing up with the marks that jinja applys when you use the safe filter
reference: https://jinja.palletsprojects.com/en/3.1.x/templates/#working-with-automatic-escaping