### PR TITLE
Fix behave DeprecationWarning: "Use 'pattern' instead"

### DIFF
--- a/behavex/outputs/report_json.py
+++ b/behavex/outputs/report_json.py
@@ -62,7 +62,8 @@ def generate_execution_info(features):
                 scenarios = feature_scenario.scenarios
             else:
                 scenarios = [feature_scenario]
-            scenario_list = _processing_scenarios(scenarios, scenario_list, id_feature)[1]
+            scenario_list = _processing_scenarios(
+                scenarios, scenario_list, id_feature)[1]
 
         if scenario_list:
             feature_info = {}
@@ -256,9 +257,9 @@ def _step_to_dict(index, step):
 def process_step_definition(step, step_info):
     definition = registry.find_step_definition(step)
     if definition:
-        hash_step = _generate_hash(definition.string)
+        hash_step = _generate_hash(definition.pattern)
         if hash_step not in global_vars.steps_definitions:
-            global_vars.steps_definitions[hash_step] = definition.string
+            global_vars.steps_definitions[hash_step] = definition.pattern
         step_info['hash'] = hash_step
     else:
         step_info['hash'] = 0


### PR DESCRIPTION
Hello!
I'm working in a Data Engineering team and we use your framework for our DAG testing.
Recently, our test results came with a bunch of these messages:
```
.../.venv/lib/python3.8/site-packages/behave/matchers.py:168: DeprecationWarning: deprecated: Use 'pattern' instead
  warnings.warn("deprecated: Use 'pattern' instead", DeprecationWarning)
```
We run our project with poetry and have BehaveX set to 3.0.0 and behave to 1.2.6, both are the latest versions.

I've modified these calls to `.string` to use `.pattern`. Installed my local version in our tool, and the warnings are now suppressed.

This is the context on behave: https://github.com/behave/behave/blob/main/behave/matchers.py#L184

Lmk if there's anything else I can do to have this applied :)