### PR TITLE
fix: remove os.getcwd() from the default value of FEATURES_PATH

### DIFF
--- a/behavex/__init__.py
+++ b/behavex/__init__.py
@@ -10,4 +10,4 @@ import os
 # Set the framework path
 os.environ['BEHAVEX_PATH'] = os.path.dirname(os.path.realpath(__file__))
 # Set the features path
-os.environ['FEATURES_PATH'] = os.environ.get('FEATURES_PATH', os.path.join(os.getcwd(), 'features'))
+os.environ['FEATURES_PATH'] = os.environ.get('FEATURES_PATH', 'features')


### PR DESCRIPTION
- most paths are resolved to absolute anyway so i believe its safe to remove it from the default value

this is a workaround for https://github.com/hrcorval/behavex/issues/153