### PR TITLE
fix: strip ansi codes on report output

### DIFF
--- a/behavex/environment.py
+++ b/behavex/environment.py
@@ -17,7 +17,7 @@ from behavex import conf_mgr
 from behavex.conf_mgr import get_env, get_param
 from behavex.global_vars import global_vars
 from behavex.outputs import report_json, report_xml
-from behavex.outputs.report_utils import create_log_path
+from behavex.outputs.report_utils import create_log_path, strip_ansi_codes
 from behavex.utils import (LOGGING_CFG, create_custom_log_when_called,
                            get_autoretry_attempts, get_logging_level,
                            get_scenario_tags, get_scenarios_instances)
@@ -197,6 +197,7 @@ def _add_log_handler(log_path):
     )
     log_level = get_logging_level()
     logging.getLogger().setLevel(log_level)
+    file_handler.addFilter(lambda record: setattr(record, 'msg', strip_ansi_codes(str(record.msg))) or True)
     file_handler.setFormatter(_get_log_formatter())
     logging.getLogger().addHandler(file_handler)
     return file_handler

--- a/behavex/outputs/report_utils.py
+++ b/behavex/outputs/report_utils.py
@@ -147,10 +147,12 @@ def gather_steps(features):
 
 
 def gather_errors(scenario, retrieve_step_name=False):
+    strip_ansi_codes = lambda text: re.sub(r'\x1B\[[0-?9;]*[mGJK]', '', text)
+    error_msg = list(map(lambda line: strip_ansi_codes(line), scenario['error_msg']))
     if retrieve_step_name:
-        return scenario['error_msg'], scenario['error_lines'], scenario['error_step']
+        return error_msg, scenario['error_lines'], scenario['error_step']
     else:
-        return scenario['error_msg'], scenario['error_lines']
+        return error_msg, scenario['error_lines']
 
 
 def pretty_print_time(seconds_float, sec_decimals=1):

--- a/behavex/outputs/report_utils.py
+++ b/behavex/outputs/report_utils.py
@@ -147,7 +147,6 @@ def gather_steps(features):
 
 
 def gather_errors(scenario, retrieve_step_name=False):
-    strip_ansi_codes = lambda text: re.sub(r'\x1B\[[0-?9;]*[mGJK]', '', text)
     error_msg = list(map(lambda line: strip_ansi_codes(line), scenario['error_msg']))
     if retrieve_step_name:
         return error_msg, scenario['error_lines'], scenario['error_step']
@@ -451,3 +450,6 @@ def get_environment_details():
     environment_details_raw_data = os.getenv('ENVIRONMENT_DETAILS', None)
     environment_details = environment_details_raw_data.split(',') if environment_details_raw_data else []
     return environment_details
+
+def strip_ansi_codes(from_str: str): 
+    return re.sub(r'\x1B\[[0-?9;]*[mGJK]', '', from_str)


### PR DESCRIPTION
## Context

I'm adding ansi colors on my assertion messages via `colorama` for better visual feedback:
![image](https://github.com/user-attachments/assets/a415654e-9c4e-452a-8123-33c04d5488c4)

These are then automatically captured in the HTML formatter. However, the ansi color codes aren't properly trimmed / escaped.
![image](https://github.com/user-attachments/assets/d5f24e84-1122-495a-b9b0-7fbc7ec415f1)

This PR strips ansi codes on `report_utils.gather_errors` before returning them.
![image](https://github.com/user-attachments/assets/1e80f503-a307-4652-b273-7f0d8ebc069b)

## PS
If the PR will be accepted, would appreciate if we can add `hacktoberfest-accepted` again please! thanks!