### PR TITLE
fix(reporting): replace scenario_info.id_hash with uuid for an edge case bug on expand / collapse

### DIFF
--- a/behavex/outputs/report_json.py
+++ b/behavex/outputs/report_json.py
@@ -27,7 +27,7 @@ from behavex.global_vars import global_vars
 from behavex.outputs.report_utils import (get_environment_details,
                                           get_error_message,
                                           match_for_execution, text)
-from behavex.utils import (generate_hash, get_scenario_tags,
+from behavex.utils import (generate_hash, generate_uuid, get_scenario_tags,
                            try_operate_descriptor)
 
 
@@ -181,8 +181,7 @@ def _processing_scenarios(scenarios, scenario_list, id_feature):
             scenario_info['error_lines'] = error_lines
             scenario_info['error_step'] = error_step
             scenario_info['error_background'] = error_background
-            scenario_info['id_hash'] = generate_hash("{}:{}".format(scenario.filename,
-                                                                    scenario.line))
+            scenario_info['id_hash'] = generate_uuid()
             if scenario.feature.name in global_vars.retried_scenarios:
                 if (
                     scenario.name

--- a/behavex/utils.py
+++ b/behavex/utils.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import sys
 import time
+import uuid
 from functools import reduce
 from tempfile import gettempdir
 
@@ -583,3 +584,6 @@ def generate_hash(word):
     hash_int = int.from_bytes(truncated_hash, byteorder='big')
     # Ensure the result fits in 48 bits (optional, for consistency)
     return hash_int & 0xFFFFFFFFFFFF
+
+def generate_uuid():
+    return uuid.uuid4().hex


### PR DESCRIPTION
## Bug

There's an edge case where the html report scenarios' `data-id-hash`  isnt created uniquely. I couldn't create a minimum reproducible example but it does happen on our project.

This is related to mutating the scenario names on runtime which we have done a fix for just recently.
![image](https://github.com/user-attachments/assets/84121aef-000d-4e6a-89a8-fd2b3c649f8c)

One of the side effects of this is that when I expand / collapse one scenario, everything expands and collapses too.
![expand-bug](https://github.com/user-attachments/assets/646d55c4-3ad3-40eb-b437-e7e13e011848)

## Proposed Fix

Instead of creating a hash based on the scenario name and line, I replaced it with a uuid instead. I'm guessing that hash is supposed to be unique anyway.

![image](https://github.com/user-attachments/assets/cbfc204d-5b61-4924-b2fc-5d89ca1a7a0c)

### PS

- sorry to ask again 😅 but if the PR gets accepted, would very much appreciate the `hacktoberfest-accepted` label please. Thank you!


