### PR TITLE
Feature: Add in support for a temporary file prefix via a CLI argument

### DIFF
--- a/behavex/arguments.py
+++ b/behavex/arguments.py
@@ -69,7 +69,7 @@ BEHAVEX_ARGS = [
     'parallel_scheme',
     'parallel_processes',
     'show_progress_bar',
-    'output_prefix'
+    'temp_output_prefix'
 ]
 
 
@@ -318,8 +318,11 @@ def parse_arguments(args):
         required=False,
     )
     parser.add_argument(
-        '--output-prefix',
-        help='Specifies a prefix for the file to write temporary data to.',
+        '-top'
+        '--temp-output-prefix',
+        help='Specifies a prefix for the file in which temporary data '
+             'is written to. Neccessary when running multiple instances '
+             'of behavex in parallel.',
         required=False,
     )
 

--- a/behavex/arguments.py
+++ b/behavex/arguments.py
@@ -69,6 +69,7 @@ BEHAVEX_ARGS = [
     'parallel_scheme',
     'parallel_processes',
     'show_progress_bar',
+    'output_prefix'
 ]
 
 
@@ -314,6 +315,11 @@ def parse_arguments(args):
         help="Shows the execution progress bar in console.",
         default=False,
         action='store_true',
+        required=False,
+    )
+    parser.add_argument(
+        '--output-prefix',
+        help='Specifies a prefix for the file to write temporary data to.',
         required=False,
     )
 

--- a/behavex/runner.py
+++ b/behavex/runner.py
@@ -830,8 +830,8 @@ def remove_temporary_files(parallel_processes, json_reports):
             except Exception as remove_ex:
                 print(remove_ex)
 
-        output_prefix = f"{get_env('OUTPUT_PREFIX')}-" if get_env("OUTPUT_PREFIX") else ""
-        path_stdout = os.path.join(gettempdir(), "{}stdout{}.txt".format(output_prefix, i + 1))
+        temp_output_prefix = get_env('TEMP_OUTPUT_PREFIX') if get_env('TEMP_OUTPUT_PREFIX') else ''
+        path_stdout = os.path.join(gettempdir(), '{}stdout{}.txt'.format(temp_output_prefix, i + 1))
         if os.path.exists(path_stdout):
             try:
                 os.chmod(path_stdout, 511)  # nosec
@@ -1040,9 +1040,9 @@ def _set_behave_arguments(features_path, multiprocess, execution_id=None, featur
         arguments.append('--no-summary')
         worker_id = multiprocessing.current_process().name.split('-')[-1]
 
-        output_prefix = f"{config.get_env('OUTPUT_PREFIX')}-" if config.get_env("OUTPUT_PREFIX") else ""
+        temp_output_prefix = get_env('TEMP_OUTPUT_PREFIX') if get_env('TEMP_OUTPUT_PREFIX') else ''
         arguments.append('--outfile')
-        arguments.append(os.path.join(gettempdir(), '{}stdout{}.txt'.format(output_prefix, worker_id)))
+        arguments.append(os.path.join(gettempdir(), '{}stdout{}.txt'.format(temp_output_prefix, worker_id)))
 
         arguments.append('-D')
         arguments.append(f'worker_id={worker_id}')

--- a/behavex/runner.py
+++ b/behavex/runner.py
@@ -830,7 +830,8 @@ def remove_temporary_files(parallel_processes, json_reports):
             except Exception as remove_ex:
                 print(remove_ex)
 
-        path_stdout = os.path.join(gettempdir(), 'stdout{}.txt'.format(i + 1))
+        output_prefix = f"{get_env('OUTPUT_PREFIX')}-" if get_env("OUTPUT_PREFIX") else ""
+        path_stdout = os.path.join(gettempdir(), "{}stdout{}.txt".format(output_prefix, i + 1))
         if os.path.exists(path_stdout):
             try:
                 os.chmod(path_stdout, 511)  # nosec
@@ -1039,8 +1040,9 @@ def _set_behave_arguments(features_path, multiprocess, execution_id=None, featur
         arguments.append('--no-summary')
         worker_id = multiprocessing.current_process().name.split('-')[-1]
 
+        output_prefix = f"{config.get_env('OUTPUT_PREFIX')}-" if config.get_env("OUTPUT_PREFIX") else ""
         arguments.append('--outfile')
-        arguments.append(os.path.join(gettempdir(), 'stdout{}.txt'.format(worker_id)))
+        arguments.append(os.path.join(gettempdir(), '{}stdout{}.txt'.format(output_prefix, worker_id)))
 
         arguments.append('-D')
         arguments.append(f'worker_id={worker_id}')


### PR DESCRIPTION
This request was initially reported in https://github.com/hrcorval/behavex/issues/184

## Bug
When running `behavex`, the temporary output on each thread will be redirected to `/{system temp folder}/stdout{index}.txt` where the index is the index of the parallel process. This causes issues if multiple instances of behavex are ran in parallel. 

## Proposed Fix
Allow the user to specify a command line argument to prefix this temporary file with a given string. This command line argument is `-top <string>` or `--temp-output-prefix <string>` and is not required. This has been tested & I can confirm that this change allows for multiple instances of `behavex` to run in parallel. 