### PR TITLE
Use minify_html instead of htmlmin

### DIFF
--- a/behavex/outputs/report_html.py
+++ b/behavex/outputs/report_html.py
@@ -11,7 +11,7 @@ import time
 from collections import OrderedDict
 
 import csscompressor
-import htmlmin
+import minify_html
 
 from behavex.conf_mgr import get_env
 from behavex.global_vars import global_vars
@@ -73,10 +73,7 @@ def _create_files_report(content_to_file):
             path_file = os.path.join(get_env('OUTPUT'), 'outputs', name_file)
             _create_manifest('', name_file)
         try:
-            content = htmlmin.minify(
-                input=content,
-                pre_tags=(u'pre', u'textarea'),
-            )
+            content = minify_html.minify(content)
         # pylint: disable= W0703
         except Exception as ex:
             print(ex)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "behavex-images",
     "jinja2",
     "configobj",
-    "htmlmin",
+    "minify-html",
     "csscompressor"
 ]
 # Add dynamic field to handle entry points

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'behavex-images',
         'jinja2',
         'configobj',
-        'htmlmin',
+        'minify-html',
         'csscompressor'
     ],
     classifiers=[


### PR DESCRIPTION
# Bug

#186 

Behavex cannot be installed with python 3.13 because behavex depends on the remove cgi module via [htmlmin](https://github.com/mankyd/htmlmin) to perform HTML minification. 

# Proposed solution 
While the change to [remove cgi from htmlmin is small](https://github.com/mankyd/htmlmin/pull/67), htmlmin hasn't been updated since Python 3.2/8 years ago, so it may not be reasonable to expect the maintainer to merge the pull request. Instead of relying on htmlmin, replace it with [minify-html](https://github.com/wilsonzlin/minify-html).

Behavex currently passes in `pre` and `textarea` as tags to exclude from minification. Likewise, minify-html does not remove whitespace in `pre` and `textarea` out of the box
* [Docs](https://github.com/wilsonzlin/minify-html/tree/master?tab=readme-ov-file#whitespace) make a specific call out to not altering whitespace in `<pre>` elements
* [Tests](https://github.com/wilsonzlin/minify-html/blob/32aacb6e219b22c4611d791ae15f27dd331ba9f5/minify-html-common/src/tests/mod.rs#L34) show that whitespace is unaffected for `pre` and `textarea` elements (HTML entity 32 is a space character)