### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,9 @@ name: Test behavex in latest python versions
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test-behavex:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/hrcorval/behavex/security/code-scanning/1](https://github.com/hrcorval/behavex/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for `actions/checkout@v2` to access the repository.
- `contents: read` is also sufficient for the `actions/upload-artifact@v4` action, as it uploads artifacts without modifying repository contents.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as no job-specific permissions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
