### PR TITLE
fix(utils): add padding and dynamically get max length when printing env vars

### DIFF
--- a/behavex/utils.py
+++ b/behavex/utils.py
@@ -328,18 +328,19 @@ def set_env_variable(key, value):
 
 
 def print_env_variables(keys):
-    key_length = 20
-    value_length = 60
-    separator = '|{}| {}|'.format(''.ljust(key_length, '-'), ''.ljust(value_length, '-'))
-    header = '|{}| {}|'.format('ENV. VARIABLE'.ljust(key_length), 'VALUE'.ljust(value_length))
+    env_data = [(key.upper(), os.environ.get(key, '----')) for key in keys]
+    pad_length = 1
+    key_length = max(len(key) for key, _ in env_data) + pad_length
+    value_length = max(len(value) for _, value in env_data) + pad_length
+
+    separator = f"|{'-' * (key_length + pad_length)}|{'-' * (value_length + pad_length)}|"
+    header = f"|{' ' * pad_length}{'ENV. VARIABLE'.ljust(key_length)}|{' ' * pad_length}{'VALUE'.ljust(value_length)}|"
 
     print(separator)
     print(header)
     print(separator)
-    for key in keys:
-        value = os.environ.get(key)
-        value = value if value else '----'
-        print('|{}| {}|'.format(key.upper().ljust(key_length), str(value).ljust(value_length)))
+    for key, value in env_data:
+        print(f"|{' ' * pad_length}{key.ljust(key_length)}|{' ' * pad_length}{value.ljust(value_length)}|")
     print(separator)
 
 


### PR DESCRIPTION
Printed env vars on launch of behavex doesn't wrap properly because of hard-coded values key and value lengths.

**Current**
<img width="1936" height="454" alt="image" src="https://github.com/user-attachments/assets/29194e65-294d-4b47-9e0d-ca4869023d08" />



**Fix**
<img width="1962" height="474" alt="image" src="https://github.com/user-attachments/assets/893a49c4-ba76-43d5-8833-3747e7741a68" />
